### PR TITLE
Migrate from kotlin-argsparser to clikt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,19 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.3.0"
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
 }
 
 repositories {
-    mavenLocal()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib"
-    compile "org.jetbrains.kotlin:kotlin-script-runtime"
-    compile "com.xenomachina:kotlin-argparser:2.0.7"
-    compile "com.github.holgerbrandl:kscript-annotations:1.2"
-    
-    testCompile "junit:junit:4.12"
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.31'
+    implementation 'org.jetbrains.kotlin:kotlin-script-runtime:1.5.31'
+    implementation 'com.github.holgerbrandl:kscript-annotations:1.4'
+
+    implementation 'com.github.ajalt.clikt:clikt:3.3.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 sourceSets.main.java.srcDirs 'src/main/kotlin'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/CliConfigTest.kt
+++ b/src/test/kotlin/CliConfigTest.kt
@@ -3,6 +3,6 @@ import org.junit.Test
 class CliConfigTest {
     @Test(expected = IllegalArgumentException::class)
     fun `--no-tag-prefix flag and --tag-prefix argument cannot be used together`() {
-        CliConfig.parse(arrayOf("--no-tag-prefix", "--tag-prefix", "v"))
+        ReleaseCommand {}.main(arrayOf("--no-tag-prefix", "--tag-prefix", "v"))
     }
 }

--- a/src/test/kotlin/ReleaseScriptTest.kt
+++ b/src/test/kotlin/ReleaseScriptTest.kt
@@ -28,7 +28,7 @@ class ReleaseScriptTest {
         val output = script.run("--help")
 
         assertTrue(output.contains("-h, --help"))
-        assertTrue(output.contains("show this help message and exit"))
+        assertTrue(output.contains("Show this message and exit"))
     }
 
     @Test


### PR DESCRIPTION
Jira: ETPAND-7709


### What has been done
1. Removed `jcenter()`
2. Migrated from https://github.com/xenomachina/kotlin-argparser to https://github.com/ajalt/clikt

- [x] Write unit tests

### How to test
Run the command below and make sure it doesn't fail
```Bash
kscript https://raw.githubusercontent.com/crunchyroll/android-library-release-script/ETPAND-7709-migrate-from-args-parser-to-clikt/src/main/kotlin/Release.kt --help
```
