### PR TITLE
Add ability to set Github labels to the version bump pull request

### DIFF
--- a/src/main/kotlin/Release.kt
+++ b/src/main/kotlin/Release.kt
@@ -314,7 +314,7 @@ class Git(
         ).apply {
             if (labels.isNotEmpty()) {
                 add("-l")
-                add(labels.joinToString(separator = " "))
+                add(labels.joinToString(separator = ","))
             }
         }.execute()
     }


### PR DESCRIPTION
Jira: [ETPAND-8224](https://jira.tenkasu.net/browse/ETPAND-8224)

### What has been done
Added one more config parameter `--labels` which could be used to set custom Github labels to the PR opened by the script.

### How to test
Run the command below and make sure it doesn't fail.
```Bash
kscript https://raw.githubusercontent.com/crunchyroll/android-library-release-script/af0de2d6b895e4d483373d60190302db800a18bb/src/main/kotlin/Release.kt --labels xxx --help
```