### PR TITLE
Run `git remote set-head` before creating GitHub PR

### DIFF
--- a/src/main/kotlin/Release.kt
+++ b/src/main/kotlin/Release.kt
@@ -286,7 +286,7 @@ class Git(
         addFilesToIndex(files)
         createCommit(version, ticket)
         "git push origin $name".execute()
-        "git remote set-head origin $name".execute()
+        "git remote set-head origin -a".execute()
         createPullRequest(version, ticket, labels)
         "git checkout master".execute()
     }

--- a/src/main/kotlin/Release.kt
+++ b/src/main/kotlin/Release.kt
@@ -286,6 +286,7 @@ class Git(
         addFilesToIndex(files)
         createCommit(version, ticket)
         "git push origin $name".execute()
+        "git remote set-head origin $name".execute()
         createPullRequest(version, ticket, labels)
         "git checkout master".execute()
     }


### PR DESCRIPTION
### What has been done
Run `git remote set-head` before creating the GitHub PR so `hub` can correctly identify `base` branch.

Ref: https://github.com/github/hub/issues/154#issuecomment-251852599